### PR TITLE
チャット画面の自動更新機能

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,6 +1,6 @@
 $(function(){
   function buildHTML(message){
-    var html = `<div class="message">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                       ${ message.user_name }
@@ -44,4 +44,32 @@ $(function(){
       alert('error');
     });
   });
+
+// メッセージの自動更新機能
+  var interval = setInterval(function(){
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      $.ajax({
+        url: location.href.json,
+        dataType: 'json',
+      })
+      .done(function(json){
+        var newestId = $('.message').last().data("message-id");
+        var appendHtml = '';
+        json.messages.forEach(function(message){
+          if (message.id > newestId) {
+            appendHtml += buildHTML(message);
+          }
+        });
+        $('.messages').append(appendHtml);
+        $(".messages").animate({
+          scrollTop: $(".messages")[0].scrollHeight
+        });
+      })
+      .fail(function(data){
+        alert('自動更新にエラーが起きました');
+      });
+    } else {
+      clearInterval(interval);
+    }
+  }, 5000);
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,10 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = Message.where(group_id: params[:group_id])
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def create

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,5 @@
 - @messages.each do |message|
-  .message
+  .message{ "data-message-id": "#{message.id}"}
     .upper-message
       .upper-message__user-name
         =message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name  @message.user.name
 json.created_at @message.created_at
 json.body       @message.body
 json.image      @message.image.to_s
+json.id         @message.id

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.messages @messages.each do |message|
+  json.user_name   message.user.name
+  json.created_at  message.created_at
+  json.body        message.body
+  json.image       message.image.to_s
+  json.id          message.id
+end


### PR DESCRIPTION
What
概要
チャット画面の自動更新

・5秒ごとにグループのメッセージ画面にいた場合のみ自動更新が行われる。
・最後のメッセージのdata-message-idを取得し、最新の投稿がそれよりも新しかった場合にhtmlのappendが行われる。

Why
UXの向上

![nov-25-2017 18-26-55](https://user-images.githubusercontent.com/30972167/33229224-4b7f09bc-d20e-11e7-985f-543807065733.gif)

